### PR TITLE
NoNewLineParagraph Bugfix

### DIFF
--- a/src/main/java/com/itextpdf/tool/xml/html/pdfelement/NoNewLineParagraph.java
+++ b/src/main/java/com/itextpdf/tool/xml/html/pdfelement/NoNewLineParagraph.java
@@ -52,7 +52,7 @@ import com.itextpdf.text.ListItem;
 import com.itextpdf.text.Paragraph;
 import com.itextpdf.text.Phrase;
 import com.itextpdf.text.api.Indentable;
-import com.itextpdf.tool.xml.html.Image;
+import com.itextpdf.text.Image;
 
 /**
  * A <CODE>NoNewLineParagraph</CODE> is a series of <CODE>Chunk</CODE>s and/or <CODE>Phrases</CODE>.


### PR DESCRIPTION
The check on line 233 currently always fails because an element will never be an instance of the image tag processor class.

```Java
Image e = Image.getInstance(imageData);
new NoNewLineParagraph(Float.NaN).add(e); // throws ClassCastException if e is non-null
```